### PR TITLE
Ctrl+Enter での一括置換に対応

### DIFF
--- a/src/components/hook.ts
+++ b/src/components/hook.ts
@@ -1305,7 +1305,7 @@ export const useTable = <T>({
         let changed = false;
 
         selection.forEach((location) => {
-            // 値に空文字列をセット
+            // 値に編集中セルの値をセット
             const cellChanged = setCellValue(editCell.value, location, cells);
             changed = changed || cellChanged;
         });


### PR DESCRIPTION
(PR用branch再作成しました)

[Excelと同様に](https://dekiru.net/article/11942/)，Ctrl+Enterでのセル一括置換に対応しました．
よろしくおねがいします．